### PR TITLE
Fixed another memory leak caused by previous commit

### DIFF
--- a/main.c
+++ b/main.c
@@ -18,6 +18,10 @@ int main(int argc, char *argv[])
         printf("This tool can only be used in files!\n");
         return EXIT_FAILURE;
     }
+    if (!file_exists(file_name)) {
+        printf("The file '%s' does not exist\n", file_name);
+        return EXIT_FAILURE;
+    }
 
     // Ajust the extension of the file
     output_file = change_extension(file_name, ".html");

--- a/src/parser.c
+++ b/src/parser.c
@@ -7,33 +7,31 @@ static int heading_length(Token *);
 
 void parse(Lexer * lexer, char * input_file_name)
 {
-    char file_string[lexer->token_count * sizeof(Token)];
-    memset(file_string, 0, 100);
+    size_t length = lexer->token_count * sizeof(Token);
+    char file_string[length];
+    memset(file_string, 0, length);
 
     for(int i = 0; i < lexer->token_count; ++i) {
         Token * token = lexer->tokens[i];
 
-        char char_string[] = "char_string";
-        char blank_line[] = "blank_line";
-        if(strcmp(token->type, char_string) == 0) {
-
-            if(strcmp(lexer->tokens[i-1]->type, "heading") == 0) {
-                int header_length= heading_length(lexer->tokens[i-1]);
-                char heading_string[strlen(token->cargo) + 6];
+        if(strcmp(token->type, "char_string") == 0) {
+            if(strcmp(lexer->tokens[i - 1]->type, "heading") == 0) {
+                int header_length = heading_length(lexer->tokens[i - 1]);
+                char heading_string[strlen(token->cargo) + 5];
                 sprintf(heading_string, "<h%d>%s\n", header_length, token->cargo);
                 strncat(file_string, heading_string, strlen(heading_string));
             }
-        } else if(strcmp(token->type, blank_line) == 0) {
+        } else if(strcmp(token->type, "blank_line") == 0) {
             strncat(file_string, "<br>\n", 5);
         }
     }
 
     FILE * markdown_file;
-    if((markdown_file = fopen(input_file_name, "wr")) != NULL) {
+    if ((markdown_file = fopen(input_file_name, "wr"))) {
         fprintf(markdown_file, "%s", file_string);
         fclose(markdown_file);
     } else {
-        perror("failed to create markdown file. Exiting");
+        perror("failed to create markdown file. Exiting\n");
     }
     return;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,16 +1,22 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include "utils.h"
 
-
-int is_directory(const char * path)
+bool is_directory(const char * path)
 {
     struct stat statbuf;
     if (stat(path, &statbuf) != 0)
         return 0;
     return S_ISDIR(statbuf.st_mode);
+}
+
+bool file_exists(const char* path) {
+    struct stat statbuf;
+    return stat(path, &statbuf) == 0;
 }
 
 char* change_extension(char* const filePath, char* const newEstension ) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,4 +1,5 @@
 #pragma once
 
-int is_directory(const char *);
+bool is_directory(const char *);
+bool file_exists(const char*);
 char* change_extension(char* const, char* const);


### PR DESCRIPTION
- Created the function ```file_exists```
- The ```marlo``` now check if the specified file to parse exists
- Fixed the call of ```memset```, using the size of ```file_string```
- Fixed the calls of ```strcmp```
- Fixed the ```heading_string```, we only need to add five chars, insted of six